### PR TITLE
Fix Kaggle dataset handle in workflows and Mongo row_index duplicate key

### DIFF
--- a/.github/workflows/_prod_publishing.yml
+++ b/.github/workflows/_prod_publishing.yml
@@ -12,6 +12,6 @@ jobs:
   call-workflow:
     uses: OpenIsraeliSupermarkets/daily-publish-supermarket-data/.github/workflows/template.yml@main
     with:
-      kaggle_dataset_remote_name: "israeli-supermarkets-2024"
+      kaggle_dataset_remote_name: "erlichsefi/israeli-supermarkets-2024"
       operation: "publishing,clean_all_source_data"
     secrets: inherit

--- a/.github/workflows/_prod_scrape.yml
+++ b/.github/workflows/_prod_scrape.yml
@@ -12,6 +12,6 @@ jobs:
   call-workflow:
     uses: OpenIsraeliSupermarkets/daily-publish-supermarket-data/.github/workflows/template.yml@main
     with:
-      kaggle_dataset_remote_name: "israeli-supermarkets-2024"
+      kaggle_dataset_remote_name: "erlichsefi/israeli-supermarkets-2024"
       operation: "scraping,converting,clean_dump_files,api_update"
     secrets: inherit

--- a/.github/workflows/emergency_upload.yml
+++ b/.github/workflows/emergency_upload.yml
@@ -10,6 +10,6 @@ jobs:
   call-workflow:
     uses: OpenIsraeliSupermarkets/daily-publish-supermarket-data/.github/workflows/template.yml@main
     with:
-      kaggle_dataset_remote_name: "israeli-supermarkets-2024"
+      kaggle_dataset_remote_name: "erlichsefi/israeli-supermarkets-2024"
       operation: "upload_no_compose"
     secrets: inherit

--- a/.github/workflows/force_refresh_api.yml
+++ b/.github/workflows/force_refresh_api.yml
@@ -10,6 +10,6 @@ jobs:
   call-workflow:
     uses: OpenIsraeliSupermarkets/daily-publish-supermarket-data/.github/workflows/template.yml@main
     with:
-      kaggle_dataset_remote_name: "israeli-supermarkets-2024"
+      kaggle_dataset_remote_name: "erlichsefi/israeli-supermarkets-2024"
       operation: "reload_complete_api"
     secrets: inherit

--- a/.github/workflows/manual_clean.yml
+++ b/.github/workflows/manual_clean.yml
@@ -10,6 +10,6 @@ jobs:
   call-workflow:
     uses: OpenIsraeliSupermarkets/daily-publish-supermarket-data/.github/workflows/template.yml@main
     with:
-      kaggle_dataset_remote_name: "israeli-supermarkets-2024"
+      kaggle_dataset_remote_name: "erlichsefi/israeli-supermarkets-2024"
       operation: "clean_dump_files,clean_all_source_data"
     secrets: inherit

--- a/.github/workflows/publishing_retry.yml
+++ b/.github/workflows/publishing_retry.yml
@@ -10,6 +10,6 @@ jobs:
   call-workflow:
     uses: OpenIsraeliSupermarkets/daily-publish-supermarket-data/.github/workflows/template.yml@main
     with:
-      kaggle_dataset_remote_name: "israeli-supermarkets-2024"
+      kaggle_dataset_remote_name: "erlichsefi/israeli-supermarkets-2024"
       operation: "upload_no_compose,clean_all_source_data"
     secrets: inherit

--- a/remotes/short_term/mongo_db.py
+++ b/remotes/short_term/mongo_db.py
@@ -87,9 +87,19 @@ class MongoDbUploader(ShortTermDatabaseUploader):
         Logger.info("Creating collection: %s", table_name)
         try:
             self.db.create_collection(table_name)
-            self.db[table_name].create_index(
-                [(partition_id, pymongo.ASCENDING)], unique=True, sparse=True
-            )
+            coll = self.db[table_name]
+            # Data rows use row_index; completion markers omit it. A plain unique index
+            # treats multiple missing keys as duplicate null (E11000 on file_complete).
+            if partition_id == "row_index":
+                coll.create_index(
+                    [(partition_id, pymongo.ASCENDING)],
+                    unique=True,
+                    partialFilterExpression={"file_complete": {"$exists": False}},
+                )
+            else:
+                coll.create_index(
+                    [(partition_id, pymongo.ASCENDING)], unique=True, sparse=True
+                )
         except pymongo.errors.PyMongoError as e:
             Logger.error("Error creating collection: %s", str(e))
 

--- a/remotes/short_term/mongo_db.py
+++ b/remotes/short_term/mongo_db.py
@@ -88,13 +88,14 @@ class MongoDbUploader(ShortTermDatabaseUploader):
         try:
             self.db.create_collection(table_name)
             coll = self.db[table_name]
-            # Data rows use row_index; completion markers omit it. A plain unique index
-            # treats multiple missing keys as duplicate null (E11000 on file_complete).
+            # Data rows include `content`; file_complete markers do not. A sparse unique
+            # index treats multiple missing row_index as duplicate null (E11000).
+            # Use a positive partial filter ($exists: true); $exists: false is not allowed.
             if partition_id == "row_index":
                 coll.create_index(
                     [(partition_id, pymongo.ASCENDING)],
                     unique=True,
-                    partialFilterExpression={"file_complete": {"$exists": False}},
+                    partialFilterExpression={"content": {"$exists": True}},
                 )
             else:
                 coll.create_index(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Kaggle:** Production workflows were passing `israeli-supermarkets-2024` as `KAGGLE_DATASET_REMOTE_NAME`. Kaggle expects `owner/slug`, so publishing failed with an invalid dataset handle. All affected workflow inputs now use `erlichsefi/israeli-supermarkets-2024` (aligned with `_prod_deploy_api.yml` and the README).

- **MongoDB:** Price collections use a unique index on `row_index`, but `file_complete` completion documents omit `row_index`. With a sparse unique index, MongoDB still treats multiple documents missing the indexed field as duplicate `null` (E11000). New collections now use a **partial** unique index on `row_index` scoped to documents that include **`content`** (data rows always have it; `file_complete` markers do not). MongoDB does not allow `$exists: false` in partial filters (code 67 / "Expression not supported in partial index"), so we use this positive predicate instead.

## Operational note

Existing collections that already have the old `row_index_1` index will keep failing until that index is dropped/recreated (e.g. after a DB reset or manual `dropIndex` + recreate). Fresh `restart_database` runs pick up the new index definition automatically.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3532cd12-d859-4e3a-a660-b4db2233371e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3532cd12-d859-4e3a-a660-b4db2233371e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

