### PR TITLE
Kafka message sizes configurable via environment variables

### DIFF
--- a/.env.templete
+++ b/.env.templete
@@ -13,6 +13,16 @@ MONGODB_URI=the_constracted_api # TBD: duplicate - to remove
 # path to store app data
 APP_DATA_PATH=path_to_app_data_folder
 
+# Kafka message size limits (bytes). Keep producer, consumer, and broker settings consistent.
+# Producer (aiokafka max_request_size):
+KAFKA_MAX_REQUEST_SIZE=2097152
+# Consumer (fetch.max.bytes and max.partition.fetch.bytes):
+KAFKA_FETCH_MAX_BYTES=2097152
+KAFKA_MAX_PARTITION_FETCH_BYTES=2097152
+# Broker (server.properties or image-specific env, e.g. Bitnami KAFKA_CFG_*):
+# message.max.bytes=<same or higher than clients>
+# replica.fetch.max.bytes=<same or higher than message.max.bytes>
+
 # Scraping Params
 # LIMIT=10
 

--- a/remotes/short_term/kafka_db.py
+++ b/remotes/short_term/kafka_db.py
@@ -39,6 +39,19 @@ class KafkaDbUploader(ShortTermDatabaseUploader):
         # promo files can be larger than 1.2B
         # Default: 2MB (2097152 bytes)
         self.max_request_size = int(os.getenv("KAFKA_MAX_REQUEST_SIZE", "2097152"))
+        # Consumer fetch.max.bytes (total fetch size per request); default matches producer cap
+        self.fetch_max_bytes = int(
+            os.getenv("KAFKA_FETCH_MAX_BYTES", str(self.max_request_size))
+        )
+        # Per-partition cap in the consumer; must not exceed fetch_max_bytes
+        default_partition_fetch = min(self.fetch_max_bytes, self.max_request_size)
+        self.max_partition_fetch_bytes = int(
+            os.getenv(
+                "KAFKA_MAX_PARTITION_FETCH_BYTES", str(default_partition_fetch)
+            )
+        )
+        if self.max_partition_fetch_bytes > self.fetch_max_bytes:
+            self.max_partition_fetch_bytes = self.fetch_max_bytes
         self.producer: Optional[AIOKafkaProducer] = None
         self.admin_client: Optional[KafkaAdminClient] = None
         self._connection_tested = False
@@ -313,7 +326,8 @@ class KafkaDbUploader(ShortTermDatabaseUploader):
                     group_id=f"test_consumer_{topic_name}_{int(time.time())}_{id(self)}",  # Unique group ID with timestamp
                     session_timeout_ms=10000,  # Increase session timeout
                     request_timeout_ms=20000,  # Increase request timeout
-                    max_partition_fetch_bytes=self.max_request_size,
+                    fetch_max_bytes=self.fetch_max_bytes,
+                    max_partition_fetch_bytes=self.max_partition_fetch_bytes,
                 )
 
                 await consumer.start()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change makes Kafka client message-size limits explicit and configurable on the consumer side, and documents all relevant settings (including broker) in the environment template.

## Producer

- `max_request_size` was already driven by `KAFKA_MAX_REQUEST_SIZE` (default 2097152). No code change.

## Consumer

- `fetch.max.bytes` is now set from `KAFKA_FETCH_MAX_BYTES` (default: same as `KAFKA_MAX_REQUEST_SIZE`).
- `max.partition.fetch.bytes` is set from `KAFKA_MAX_PARTITION_FETCH_BYTES` (default: `min(fetch_max_bytes, max_request_size)`). Values above `fetch_max_bytes` are clamped so the client configuration stays valid.

## Broker

- This repo does not run a Kafka broker in `docker-compose.yml`. `.env.templete` now documents that operators should set `message.max.bytes` and `replica.fetch.max.bytes` on the broker (e.g. via `server.properties` or image-specific env such as Bitnami `KAFKA_CFG_*`) in line with client limits.

## Files

- `remotes/short_term/kafka_db.py` — consumer env wiring and clamp
- `.env.templete` — documented variables for operators
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1320daae-5136-4600-a122-c4ca940a0e5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1320daae-5136-4600-a122-c4ca940a0e5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

