### PR TITLE
Fix api_update BSON failures and improve failure logging

### DIFF
--- a/managers/short_term_database_manager.py
+++ b/managers/short_term_database_manager.py
@@ -3,28 +3,13 @@ import os
 import pandas as pd
 import json
 from utils import Logger
+from utils.mongo_sanitize import sanitize_for_mongo
 from remotes import ShortTermDatabaseUploader
 from managers.cache_manager import CacheManager, CacheState
 from managers.large_file_push_manager import LargeFilePushManager
 from il_supermarket_parsers import ParserStatusOutput
 from il_supermarket_scarper import ScraperStatusOutput
 from typing import Union
-
-
-_MONGO_INT_MAX = 2**63 - 1
-_MONGO_INT_MIN = -(2**63)
-
-
-def _sanitize_for_mongo(obj):
-    """Recursively convert integers that exceed MongoDB's 8-byte limit to strings."""
-    if isinstance(obj, dict):
-        return {k: _sanitize_for_mongo(v) for k, v in obj.items()}
-    if isinstance(obj, list):
-        return [_sanitize_for_mongo(v) for v in obj]
-    if isinstance(obj, int) and not isinstance(obj, bool):
-        if obj > _MONGO_INT_MAX or obj < _MONGO_INT_MIN:
-            return str(obj)
-    return obj
 
 
 class ShortTermDBDatasetManager:
@@ -87,7 +72,9 @@ class ShortTermDBDatasetManager:
                             continue
                         pushed_set.add(row_index)
                         added_ids.append(row_index)
-                        processed_events.append(_sanitize_for_mongo({"index": row_index, **event_json}))
+                        processed_events.append(
+                            sanitize_for_mongo({"index": row_index, **event_json})
+                        )
                     self.uploader._insert_to_destinations(
                         target_table, processed_events
                     )
@@ -102,7 +89,9 @@ class ShortTermDBDatasetManager:
                             continue
                         if row_index in pushed_set:
                             continue
-                        processed_events.append(_sanitize_for_mongo({"index": row_index, **event_json}))
+                        processed_events.append(
+                            sanitize_for_mongo({"index": row_index, **event_json})
+                        )
                         pushed_set.add(row_index)
                         added_ids.append(row_index)
 

--- a/publishers/dag_publisher.py
+++ b/publishers/dag_publisher.py
@@ -63,7 +63,8 @@ class SupermarketDataPublisherInterface(BaseSupermarketDataPublisher):
         Logger.info("Starting executing DAG = %s", operations)
         self._check_tz()
 
-        for operation in operations.split(","):
+        for raw_op in operations.split(","):
+            operation = raw_op.strip()
             Logger.info(f"DAG is {operations} starting the operation=%s", operation)
 
             # Mark operation as started in heartbeat
@@ -78,9 +79,22 @@ class SupermarketDataPublisherInterface(BaseSupermarketDataPublisher):
                 Logger.info("Done the operation=%s", operation)
 
             except Exception as e:
-                # Mark operation as failed
+                err_parts = [str(e)]
+                if hasattr(e, "errors"):
+                    try:
+                        err_parts.append(f"errors={e.errors()}")
+                    except Exception:
+                        pass
+                if isinstance(e, KeyError) and e.args:
+                    err_parts.append(f"missing_key={e.args[0]!r}")
+                err_detail = " | ".join(err_parts)
                 self.heartbeat.complete_operation(
-                    operation, success=False, error=str(e)
+                    operation, success=False, error=err_detail
                 )
-                Logger.error(f"Operation {operation} failed: {e}")
+                Logger.error(
+                    "Operation %s failed; detail: %s",
+                    operation,
+                    err_detail,
+                    exc_info=True,
+                )
                 # raise  # Re-raise the exception to maintain original behavior

--- a/remotes/short_term/mongo_db.py
+++ b/remotes/short_term/mongo_db.py
@@ -5,11 +5,14 @@ handling large integers, collection management, and status tracking.
 """
 
 from utils import Logger
+from utils.mongo_sanitize import sanitize_for_mongo
 import os
 import re
 from datetime import datetime, timedelta
 
 import pymongo
+from bson import encode as bson_encode
+from bson.errors import InvalidDocument
 
 from .api_base import ShortTermDatabaseUploader
 
@@ -55,12 +58,34 @@ class MongoDbUploader(ShortTermDatabaseUploader):
         if not items:
             return
 
+        items = [sanitize_for_mongo(item) for item in items]
+
         Logger.info("Pushing to table %s, %d items", table_target_name, len(items))
         collection = self.db[table_target_name]
 
         try:
             collection.insert_many(items, ordered=False)
             Logger.info("Successfully inserted %d records to MongoDB", len(items))
+        except InvalidDocument as e:
+            for idx, record in enumerate(items):
+                try:
+                    bson_encode(record)
+                except Exception as doc_err:
+                    Logger.error(
+                        "BSON encoding failed for table %s at item index %s: %s. "
+                        "Offending document (truncated repr, first 2000 chars): %s",
+                        table_target_name,
+                        idx,
+                        doc_err,
+                        repr(record)[:2000],
+                    )
+                    raise doc_err from e
+            Logger.error(
+                "BSON InvalidDocument for table %s but per-record encode did not isolate: %s",
+                table_target_name,
+                e,
+            )
+            raise
         except pymongo.errors.BulkWriteError as e:
             Logger.warning("Bulk insert failed, trying individual inserts: %s", str(e))
             successful_records = 0
@@ -71,6 +96,10 @@ class MongoDbUploader(ShortTermDatabaseUploader):
                         successful_records += 1
                     except pymongo.errors.PyMongoError as inner_e:
                         Logger.error("Failed to insert record: %s", str(inner_e))
+                        Logger.error(
+                            "Offending record (truncated repr): %s",
+                            repr(record)[:2000],
+                        )
             Logger.info(
                 "Successfully inserted %d/%d records individually",
                 successful_records,

--- a/utils/heartbeat.py
+++ b/utils/heartbeat.py
@@ -114,9 +114,15 @@ class HeartbeatManager:
             }
 
         self._write_heartbeat(data)
-        Logger.info(
-            f"Heartbeat: Completed operation '{operation}' with status '{data['operations'][operation]['status']}'"
+        status = data["operations"][operation]["status"]
+        msg = (
+            f"Heartbeat: Completed operation '{operation}' with status '{status}'"
         )
+        if success:
+            Logger.info(msg)
+        else:
+            err_text = data["operations"][operation].get("error") or "(no message)"
+            Logger.error("%s. Error detail: %s", msg, err_text)
 
     def update_heartbeat(self):
         """

--- a/utils/mongo_sanitize.py
+++ b/utils/mongo_sanitize.py
@@ -1,0 +1,61 @@
+"""Normalize values for MongoDB/BSON and JSON serialization.
+
+Pandas and NumPy types from CSV rows are not BSON-encodable; this module
+recursively converts them to plain Python values.
+"""
+
+from __future__ import annotations
+
+import math
+from decimal import Decimal
+from typing import Any
+
+_MONGO_INT_MAX = 2**63 - 1
+_MONGO_INT_MIN = -(2**63)
+
+
+def sanitize_for_mongo(obj: Any) -> Any:
+    """Recursively convert objects to BSON-safe Python types."""
+    if isinstance(obj, dict):
+        return {k: sanitize_for_mongo(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [sanitize_for_mongo(v) for v in obj]
+    if isinstance(obj, tuple):
+        return tuple(sanitize_for_mongo(v) for v in obj)
+    if obj is None or isinstance(obj, (bool, bytes, str)):
+        return obj
+
+    try:
+        import numpy as np
+
+        if isinstance(obj, np.ndarray):
+            return sanitize_for_mongo(obj.tolist())
+        if isinstance(obj, np.generic):
+            return sanitize_for_mongo(obj.item())
+    except ImportError:
+        pass
+
+    try:
+        import pandas as pd
+
+        if obj is pd.NA:
+            return None
+        if isinstance(obj, pd.Timestamp):
+            if pd.isna(obj):
+                return None
+            return obj
+    except ImportError:
+        pass
+
+    if isinstance(obj, float):
+        if math.isnan(obj) or math.isinf(obj):
+            return None
+
+    if isinstance(obj, Decimal):
+        return sanitize_for_mongo(float(obj))
+
+    if isinstance(obj, int) and not isinstance(obj, bool):
+        if obj > _MONGO_INT_MAX or obj < _MONGO_INT_MIN:
+            return str(obj)
+
+    return obj


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`api_update` was failing because rows built from pandas CSV chunks often contain **NumPy scalars** (for example `numpy.int64`) and sometimes **pandas `NA`/`NaT`**, which PyMongo/BSON cannot encode. That surfaced as a failed heartbeat operation with little actionable detail in logs.

## Changes

- Introduced `utils/mongo_sanitize.sanitize_for_mongo()` to recursively normalize values for MongoDB: NumPy types, pandas `NA` and invalid `Timestamp`, `Decimal`, out-of-range integers (existing behavior), `inf`/`nan` floats.
- Applied sanitization on every document in `MongoDbUploader._insert_to_destinations` before `insert_many`, and kept the same helper for status JSON in `ShortTermDBDatasetManager`.
- If BSON encoding still fails, log the **first failing item index** and a **truncated repr** of the offending document.
- On individual `insert_one` failures after a bulk write error, log a truncated repr of the offending record.
- **DAG**: strip whitespace from operation names (so `api_update` with stray spaces does not raise `Invalid operation`).
- **Heartbeat**: on failure, emit an **error-level** log line that includes the stored error detail (not only `status=failed`).
- **DAG publisher**: append Pydantic `errors()` when present, `KeyError` key when relevant, and use `exc_info=True` for stack traces.

## Testing

Local `pytest` for managers/remotes was blocked in this environment by a broken `kafka-python` import (`kafka.vendor.six.moves`); BSON sanitization was verified manually with `bson.encode` on representative payloads.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b00b6e20-081d-4eff-a7ca-267fa105de15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b00b6e20-081d-4eff-a7ca-267fa105de15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

