### PR TITLE
Fix MongoDB int64 overflow during api_update

### DIFF
--- a/managers/large_file_push_manager.py
+++ b/managers/large_file_push_manager.py
@@ -4,6 +4,7 @@ import pandas as pd
 from remotes import ShortTermDatabaseUploader
 from managers.cache_manager import CacheState
 from data_models.raw_schema import DataTable, file_name_to_table
+from utils.mongo_bson import sanitize_for_mongo
 
 
 class LargeFilePushManager:
@@ -68,7 +69,7 @@ class LargeFilePushManager:
                 if pd.isna(chunk.iloc[0]['file_name']) or pd.isna(chunk.iloc[0]['found_folder']):
                     Logger.critical(f"First row is empty, critical error,exiting... ")
                     break
-                
+
 
             # Set index releative to the 'last_row'
             stop_index = last_row + 1 + chunk.shape[0]
@@ -128,14 +129,17 @@ class LargeFilePushManager:
             if last_row_saw is not None:
                 items = items[1:]
 
-            self.database_manager._insert_to_destinations(target_table_name, items)
+            self.database_manager._insert_to_destinations(
+                target_table_name, [sanitize_for_mongo(item) for item in items]
+            )
             if eof_to_send:
                 if last_row_saw is not None:
                     for eof in eof_to_send:
                         if eof["file_name"] == last_row_saw.iloc[0].file_name:
                             eof["total_expected_records"] -= 1
                 self.database_manager._insert_to_destinations(
-                    target_table_name, eof_to_send
+                    target_table_name,
+                    [sanitize_for_mongo(e) for e in eof_to_send],
                 )
             # Save last row for next iteration
             last_row_saw = chunk.tail(1).set_index("row_index")
@@ -144,11 +148,13 @@ class LargeFilePushManager:
             self.database_manager._insert_to_destinations(
                 target_table_name,
                 [
-                    {
-                        "file_complete": "true",
-                        "file_name": open_file,
-                        "total_expected_records": total_expected_records,
-                    }
+                    sanitize_for_mongo(
+                        {
+                            "file_complete": "true",
+                            "file_name": open_file,
+                            "total_expected_records": total_expected_records,
+                        }
+                    )
                 ],
             )
         # Update cache with last processed row

--- a/managers/short_term_database_manager.py
+++ b/managers/short_term_database_manager.py
@@ -10,21 +10,7 @@ from il_supermarket_parsers import ParserStatusOutput
 from il_supermarket_scarper import ScraperStatusOutput
 from typing import Union
 
-
-_MONGO_INT_MAX = 2**63 - 1
-_MONGO_INT_MIN = -(2**63)
-
-
-def _sanitize_for_mongo(obj):
-    """Recursively convert integers that exceed MongoDB's 8-byte limit to strings."""
-    if isinstance(obj, dict):
-        return {k: _sanitize_for_mongo(v) for k, v in obj.items()}
-    if isinstance(obj, list):
-        return [_sanitize_for_mongo(v) for v in obj]
-    if isinstance(obj, int) and not isinstance(obj, bool):
-        if obj > _MONGO_INT_MAX or obj < _MONGO_INT_MIN:
-            return str(obj)
-    return obj
+from utils.mongo_bson import sanitize_for_mongo
 
 
 class ShortTermDBDatasetManager:
@@ -87,7 +73,7 @@ class ShortTermDBDatasetManager:
                             continue
                         pushed_set.add(row_index)
                         added_ids.append(row_index)
-                        processed_events.append(_sanitize_for_mongo({"index": row_index, **event_json}))
+                        processed_events.append(sanitize_for_mongo({"index": row_index, **event_json}))
                     self.uploader._insert_to_destinations(
                         target_table, processed_events
                     )
@@ -102,7 +88,7 @@ class ShortTermDBDatasetManager:
                             continue
                         if row_index in pushed_set:
                             continue
-                        processed_events.append(_sanitize_for_mongo({"index": row_index, **event_json}))
+                        processed_events.append(sanitize_for_mongo({"index": row_index, **event_json}))
                         pushed_set.add(row_index)
                         added_ids.append(row_index)
 

--- a/utils/mongo_bson.py
+++ b/utils/mongo_bson.py
@@ -1,0 +1,29 @@
+"""Helpers for values that BSON / MongoDB can represent."""
+
+_MONGO_INT_MAX = 2**63 - 1
+_MONGO_INT_MIN = -(2**63)
+
+try:
+    import numpy as np
+
+    _NUMPY_INTEGER_TYPES = (np.integer,)
+except ImportError:  # pragma: no cover - numpy is a transitive dep (pandas)
+    _NUMPY_INTEGER_TYPES = ()
+
+
+def sanitize_for_mongo(obj):
+    """Recursively convert integers that exceed MongoDB's 8-byte limit to strings.
+
+    Also normalizes numpy integer scalars so out-of-range values are detected
+    (e.g. unsigned values above 2**63 - 1).
+    """
+    if isinstance(obj, dict):
+        return {k: sanitize_for_mongo(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [sanitize_for_mongo(v) for v in obj]
+    if isinstance(obj, _NUMPY_INTEGER_TYPES):
+        obj = int(obj)
+    if isinstance(obj, int) and not isinstance(obj, bool):
+        if obj > _MONGO_INT_MAX or obj < _MONGO_INT_MIN:
+            return str(obj)
+    return obj


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `api_update` operation uploads parsed CSV rows through `LargeFilePushManager`. PyMongo/BSON only supports signed 64-bit integers. Values larger than that (common for barcodes or other IDs, or `numpy` unsigned integers above `2**63 - 1`) caused inserts to fail with: *MongoDB can only handle up to 8-byte ints*.

## Changes

- Added `utils/mongo_bson.py` with a shared `sanitize_for_mongo()` that recursively stringifies out-of-range integers and normalizes `numpy.integer` scalars before range checks.
- Applied sanitization to every `_insert_to_destinations` call in `LargeFilePushManager` (row batches, end-of-file markers, and the trailing `file_complete` document).
- Replaced the duplicate private sanitizer in `ShortTermDBDatasetManager` with an import of the shared helper (behavior unchanged for status uploads).

## Testing

Local `pytest` for the affected modules could not be run in this environment because `kafka-python` fails to import on Python 3.12 (`kafka.vendor.six.moves`). The change is a thin wrapper around existing status-path logic extended to CSV payloads.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3a5c8ed-0e0e-4b6d-a638-9f2587990169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3a5c8ed-0e0e-4b6d-a638-9f2587990169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

