### PR TITLE
chore: disable api_update in production scrape

### DIFF
--- a/.github/workflows/_prod_scrape.yml
+++ b/.github/workflows/_prod_scrape.yml
@@ -13,5 +13,5 @@ jobs:
     uses: OpenIsraeliSupermarkets/daily-publish-supermarket-data/.github/workflows/template.yml@main
     with:
       kaggle_dataset_remote_name: "erlichsefi/israeli-supermarkets-2024"
-      operation: "scraping,converting,clean_dump_files,api_update"
+      operation: "scraping,converting,clean_dump_files"
     secrets: inherit


### PR DESCRIPTION
## Summary
- Remove `api_update` from the production scrape `OPERATION` list so scheduled scrapes only run `scraping,converting,clean_dump_files`.
- Motivated by a ~5.7h prod run where Mongo `api_update` alone took ~3h 47m.

## Test plan
- [ ] Confirm CI on this PR
- [ ] After merge, verify next scheduled scrape completes without `api_update`
- [ ] Confirm API refresh still happens via dedicated workflows if needed (`force_refresh_api` / publishing path)


Made with [Cursor](https://cursor.com)