### PR TITLE
chore: bump il-supermarket-scraper>=1.0.8, il-supermarket-parser>=1.0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 il-supermarket-scraper>=1.0.8
-il-supermarket-parser>=1.0.5
+il-supermarket-parser>=1.0.6
 kagglehub==1.0.0
 schedule==1.2.2
 fastapi[all]==0.109.2


### PR DESCRIPTION
## Summary
- Bump dependency floors: the latest weekly-release run on both libraries is green.
- Scrapers: `il-supermarket-scraper>=1.0.8`
- Parsers: `il-supermarket-parser>=1.0.6`

## Test plan
- [ ] Wait for System Test on PR to Main
- [ ] Human merge when green (no auto-merge)